### PR TITLE
util: require unpack in retro-compatible fashion

### DIFF
--- a/util/init.lua
+++ b/util/init.lua
@@ -20,6 +20,9 @@
 local awful   = require("awful")
 local naughty = require("naughty")
 
+-- local modules
+local unpack = require("amh.util.unpack") -- compatibility with Lua 5.1
+
 -- other modules
 require("pl.stringx").import()
 

--- a/util/menu_iterator.lua
+++ b/util/menu_iterator.lua
@@ -21,6 +21,9 @@
 -- awesome modules
 local naughty = require("naughty")
 
+-- local modules
+local unpack = require("amh.util.unpack") -- compatibility with Lua 5.1
+
 local state = { cid = nil }
 
 local function naughty_destroy_callback(reason)

--- a/util/unpack.lua
+++ b/util/unpack.lua
@@ -1,0 +1,5 @@
+
+return unpack or table.unpack -- 5.1 Lua compatibility
+
+-- vim: set sts=4 ts=4 sw=4 tw=120 et :
+


### PR DESCRIPTION
Retro-compatibility with Lua 5.1.

See [lua 5.2 documentation][52doc] where `unpack` changed from [lua 5.1][51doc] to `table.unpack`.

[51doc]: https://www.lua.org/manual/5.1/
[52doc]: https://www.lua.org/manual/5.2/